### PR TITLE
Add cover documents to the documents section

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -56,6 +56,7 @@ const Index = withTranslation("index")(
       title = "No name",
       price,
       documents = [],
+      cover = [],
       histories = [],
       ...rest
     } = licenseData;
@@ -100,7 +101,7 @@ const Index = withTranslation("index")(
           }
           extraContent={IndexExtraContent({
             histories,
-            documents,
+            documents: [...documents, ...cover],
             fileURI,
             checksums,
           })}


### PR DESCRIPTION
The issue was that we had two types of documents in Creatorshub: documents and covers. We were adding checksums for both types in the Creatorshub and showing only documents in Metaproof. The preview URLs added in Creatorshub also are not correct and we should fix them.