### PR TITLE
feat(metrics): kunstleben

### DIFF
--- a/components/layout/modernLayout.js
+++ b/components/layout/modernLayout.js
@@ -61,7 +61,7 @@ export const ModernLayout = ({
   return (
     <LayoutContainer>
       <FluidContainer white>
-        <ModernHeader buyUrl={`${filteredURL}/nfts/${nftId}`} />
+        <ModernHeader buyUrl={`https://${filteredURL}/nfts/${nftId}`} />
       </FluidContainer>
 
       <Container>

--- a/pages/nft/[nftId]/index.js
+++ b/pages/nft/[nftId]/index.js
@@ -132,7 +132,7 @@ const IndexNftPage = ({ nftId, platform, redirectUrl }) => {
 
       {/*</CreatorWrapper>*/}
       <BuyRow>
-        <Button onClick={() => router.push(`${filteredURL}/nfts/${nftId}`)}>Buy this NFT</Button>
+        <Button onClick={() => router.push(`https://${filteredURL}/nfts/${nftId}`)}>Buy this NFT</Button>
       </BuyRow>
       <CardsContainer>
         <ModuleDivider>

--- a/pages/nft/[nftId]/index.js
+++ b/pages/nft/[nftId]/index.js
@@ -80,8 +80,6 @@ const IndexNftPage = ({ nftId, platform, redirectUrl }) => {
       ? GEO_VISUALIZATION_COUNTRY_CODES
       : metricsData?.highlightedCountries;
 
-
-
   const filteredURL = filterURL(redirectUrl);
 
   const geoCountriesNames = finalHighlightedCountries?.map(
@@ -259,6 +257,34 @@ const IndexNftPage = ({ nftId, platform, redirectUrl }) => {
             />
           </GeoContainer>
         </ModuleDivider>
+        {metricsData?.printLicensingAgreement ? (
+          <>
+            <BorderLine />
+            <ModuleDivider>
+              <H5 content="Print Licensing Agreement" />
+              {metricsData?.printLicensingAgreement ? (
+                <H1 content="Active" />
+              ) : (
+                <H1 content="Non active" />
+              )}
+              <ContentText mt={2} fontWeight="bold">
+                {metricsData?.printLicensingDescription}
+              </ContentText>
+            </ModuleDivider>
+          </>
+        ) : null}
+        {metricsData?.publicationRight ? (
+          <>
+            <BorderLine />
+            <ModuleDivider>
+              <H5 content="Print Licensing Agreement" />
+              <H1 content={metricsData?.publicationRight} />
+              <ContentText mt={2} fontWeight="bold">
+                {metricsData?.publicationRightDescription}
+              </ContentText>
+            </ModuleDivider>
+          </>
+        ) : null}
         <BorderLine />
         <InsightsContainer
           target="_blank"
@@ -312,6 +338,7 @@ const NftData = styled.div`
     align-items: center;
     max-height: 100%;
   }
+
   img {
     border-radius: 32px !important;
     object-fit: cover;
@@ -324,7 +351,7 @@ const NftData = styled.div`
 const NftContent = styled.div`
   flex: 1;
   margin-left: 24px;
-  @media(max-width: 767px){
+  @media (max-width: 767px) {
     margin: 0;
   }
 `;
@@ -498,14 +525,16 @@ const NftWrapper = styled.div`
   ${({ theme }) => theme.breakpoints.down("md")} {
     padding: 30px;
   }
-  @media(max-width: 767px){
-  padding: 1rem;
+
+  @media (max-width: 767px) {
+    padding: 1rem;
   }
+
   h2 {
     width: 100%;
     text-align: start;
 
-    @media(max-width: 767px){
+    @media (max-width: 767px) {
       text-align: center;
     }
   }
@@ -533,7 +562,7 @@ const InsightsContainer = styled.a`
     color: white;
   }
 
-  @media(max-width: 767px){
+  @media (max-width: 767px) {
     padding: 1.5rem 1rem;
     margin: 0;
   }
@@ -549,7 +578,7 @@ const ModuleDivider = styled.div`
   flex-direction: column;
   align-items: flex-start;
 
-  @media(max-width: 767px){
+  @media (max-width: 767px) {
     width: 100%;
     padding: 1rem 1.5rem;
   }


### PR DESCRIPTION
[TICKET](https://license.atlassian.net/browse/CREATOR-4864?atlOrigin=eyJpIjoiZTY2ODAyYjc1OWNiNDA2M2JkNmFmNTVlYjdmMWRiOTUiLCJwIjoiaiJ9)

### 📝 Description

Kunstleben needed a license metric displayed to their NFTs on storefront. Proof meta code update part is necessary to display new blocks of content.

### 👨‍🚀 How to test?

- Deploy this branch to production, preview can not be supported cause of some devops issues.
- Deploy [this](https://github.com/LicenseRocks/creators-hub/pull/1596) branch from creators-hub to collectiveberlin,
- Deploy [this](https://github.com/LicenseRocks/storefront-kunstleben/pull/72) branch on kunstleben storefront,
- go to the view of an NFT on storefront,
- <img width="989" alt="Screenshot 2023-08-17 at 07 19 55" src="https://github.com/LicenseRocks/meta-proof/assets/65904012/66e4c16c-1fd9-43fc-b49e-d8d615a35480">
- click private license,
<img width="336" alt="Screenshot 2023-08-17 at 07 20 19" src="https://github.com/LicenseRocks/meta-proof/assets/65904012/87184134-69b2-4725-b288-e04128ddf625">
- see new license and look if the description of the [ticket](https://license.atlassian.net/browse/CREATOR-4864?atlOrigin=eyJpIjoiZTY2ODAyYjc1OWNiNDA2M2JkNmFmNTVlYjdmMWRiOTUiLCJwIjoiaiJ9) matches the data
<img width="978" alt="Screenshot 2023-08-17 at 07 22 12" src="https://github.com/LicenseRocks/meta-proof/assets/65904012/ae349e9a-47e1-428e-b3b0-b486d1c837c4">
